### PR TITLE
fix: ignore configs/config.yaml and configs/prometheus.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,6 @@
 # Configs
 !/configs
 !/configs/**/*
+/configs/config.yaml
+/configs/prometheus.yaml
 


### PR DESCRIPTION
Update .gitignore to ignore:

- configs/config.yaml
- configs/prometheus.yaml

This files should not commit in the repository, and every environment should create them.