### PR TITLE
build(deps): confluent-kafka-go/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/RedHatInsights/cloudwatch v0.0.0-20210111105023-1df2bdfe3291
 	github.com/aws/aws-sdk-go v1.55.7
-	// github.com/confluentinc/confluent-kafka-go/v2/kafka v2.13.0
+	github.com/confluentinc/confluent-kafka-go/v2 v2.13.0
 	github.com/getkin/kin-openapi v0.131.0
 	github.com/go-playground/validator/v10 v10.27.0
 	github.com/golang-migrate/migrate/v4 v4.18.3
@@ -42,8 +42,6 @@ require (
 	gorm.io/gorm v1.30.0
 	k8s.io/utils v0.0.0-20250604170112-4c0f3b243397
 )
-
-require github.com/confluentinc/confluent-kafka-go/v2 v2.13.0
 
 require (
 	github.com/apapsch/go-jsonmerge/v2 v2.0.0 // indirect

--- a/internal/api/event/todo_created.event.json
+++ b/internal/api/event/todo_created.event.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema",
-    "$id": "https://github.com/podengo-project/idmsvc-backend/internal/api/todo_created.event.yaml",
     "title": "Event Todo created",
     "description": "Message schema for todo creation event",
     "type": "object",


### PR DESCRIPTION
The latest version of confluente-kafka-go has support for aarch64 architecture.