### PR TITLE
Potential fix for code scanning alert no. 3: Slice memory allocation with excessive size value

### DIFF
--- a/internal/infrastructure/service/impl/mock/rbac/impl/rbac_handler.go
+++ b/internal/infrastructure/service/impl/mock/rbac/impl/rbac_handler.go
@@ -29,6 +29,9 @@ func (m *mockRbac) accessHandler(c echo.Context) error {
 		linksLast     = "last"
 		linksPrevious = "previous"
 		linksNext     = "next"
+
+		// maxPageSize defines an upper bound for user-controlled pagination limits
+		maxPageSize = 1000
 	)
 	var (
 		page   Page
@@ -80,6 +83,9 @@ func (m *mockRbac) accessHandler(c echo.Context) error {
 
 	if limit <= 0 {
 		limit = 100
+	}
+	if limit > maxPageSize {
+		limit = maxPageSize
 	}
 
 	if offset < 0 {


### PR DESCRIPTION
Potential fix for [https://github.com/avisiedo/idmsvc-backend/security/code-scanning/3](https://github.com/avisiedo/idmsvc-backend/security/code-scanning/3)

In general, to fix this class of problem, clamp user-controlled size parameters (like pagination limits) to a reasonable upper bound before using them in `make` or other allocation operations. This prevents a client from forcing the server to allocate unbounded memory.

For this specific code, the best fix is:
- Introduce a constant maximum page size within `accessHandler` (or use an existing one if defined elsewhere, but we can’t assume that).
- After parsing `limit` and normalizing it (`if limit <= 0 { limit = 100 }`), add an upper-bound check, e.g. `if limit > maxPageSize { limit = maxPageSize }`.
- Optionally, ensure `offset` is also within reasonable bounds, but for CodeQL’s concern, bounding `limit` suffices because `size` is derived from `limit`.

Concretely:
- In `internal/infrastructure/service/impl/mock/rbac/impl/rbac_handler.go`, inside `accessHandler`, extend the existing `const` block to define a `maxPageSize` (or similar).
- After the existing `if limit <= 0 { limit = 100 }` block, add a new block that clamps `limit` to this maximum.
- No new imports or external packages are needed; everything uses built-in types and operations.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
