### PR TITLE
feat: use container layer as cache

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -9,7 +9,7 @@ LABEL idmsvc-backend=builder
 ENV OPENSSL_FORCE_FIPS_MODE=1
 WORKDIR /go/src/app
 COPY go.mod go.sum .
-RUN make get-deps
+RUN go mod download
 USER 0
 COPY . .
 RUN make build

--- a/scripts/mk/container.mk
+++ b/scripts/mk/container.mk
@@ -56,8 +56,6 @@ container-build:  ## Build image CONTAINER_IMAGE from CONTAINER_FILE using the C
 	  -t "$(CONTAINER_IMAGE)" \
 	  $(CONTAINER_CONTEXT_DIR) \
 	  -f "$(CONTAINER_FILE)"
-	@# prune builder container
-	$(CONTAINER_ENGINE) image prune --filter label=idmsvc-backend=builder --force
 
 .PHONY: container-push
 container-push:  ## Push image to remote registry


### PR DESCRIPTION
Retrieve the dependencies in one layer to avoid download every time the container image is built.